### PR TITLE
APP-243 Bug (iOS): email links aren't opening when Freespoke App set default browser

### DIFF
--- a/Client/Info.plist
+++ b/Client/Info.plist
@@ -40,21 +40,7 @@
 			<array>
 				<string>$(MOZ_PUBLIC_URL_SCHEME)</string>
 				<string>$(MOZ_INTERNAL_URL_SCHEME)</string>
-			</array>
-		</dict>
-		<dict>
-			<key>CFBundleTypeRole</key>
-			<string>Editor</string>
-			<key>CFBundleURLSchemes</key>
-			<array>
 				<string>http</string>
-			</array>
-		</dict>
-		<dict>
-			<key>CFBundleTypeRole</key>
-			<string>Editor</string>
-			<key>CFBundleURLSchemes</key>
-			<array>
 				<string>https</string>
 			</array>
 		</dict>

--- a/Client/Info.plist
+++ b/Client/Info.plist
@@ -26,7 +26,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.2.1</string>
+	<string>2.2.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -46,7 +46,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>5</string>
+	<string>2</string>
 	<key>INIntentsSupported</key>
 	<array>
 		<string>QuickActionIntent</string>

--- a/Fennec_Staging-Info.plist
+++ b/Fennec_Staging-Info.plist
@@ -40,21 +40,7 @@
 			<array>
 				<string>$(MOZ_PUBLIC_URL_SCHEME)</string>
 				<string>$(MOZ_INTERNAL_URL_SCHEME)</string>
-			</array>
-		</dict>
-		<dict>
-			<key>CFBundleTypeRole</key>
-			<string>Editor</string>
-			<key>CFBundleURLSchemes</key>
-			<array>
 				<string>http</string>
-			</array>
-		</dict>
-		<dict>
-			<key>CFBundleTypeRole</key>
-			<string>Editor</string>
-			<key>CFBundleURLSchemes</key>
-			<array>
 				<string>https</string>
 			</array>
 		</dict>


### PR DESCRIPTION
[APP-243 Bug (iOS): email links aren't opening when Freespoke App set default browser](https://linear.app/freespoke/issue/APP-243/bug-ios-email-links-arent-opening-when-freespoke-app-set-default)